### PR TITLE
Remove 100vw to prevent horizontal scrollbar

### DIFF
--- a/lib/src/components/App.scss
+++ b/lib/src/components/App.scss
@@ -5,7 +5,6 @@ $buttonColor: #348aa7;
 body {
   font-family: "Lucida Sans", "Lucida Sans Regular", "Lucida Grande", "Lucida Sans Unicode", Geneva, Verdana, sans-serif;
   min-width: 360px;
-  width: 100vw;
 }
 
 .ant-spin-spinning.middleSpinner {


### PR DESCRIPTION
When an element is set to `width: 100vw` and there is a vertical scrollbar - which will also take up a space - there will also be a horizontal scrollbar.

![image](https://user-images.githubusercontent.com/2201819/84692098-2ab84d80-aefa-11ea-8ccf-857e33e96572.png)
